### PR TITLE
fix: Puppeteerに--no-sandboxオプションを追加してCI環境での起動エラーを修正

### DIFF
--- a/pdf-configs/config.js
+++ b/pdf-configs/config.js
@@ -13,4 +13,7 @@ module.exports = {
     "footerTemplate": "<section>\n  <div>\n    <span class=\"pageNumber\"></span>\n    / <span class=\"totalPages\"></span>\n  </div>\n</section>"
   },
   stylesheet_encoding: "utf-8",
+  launch_options: {
+    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+  },
 };


### PR DESCRIPTION
## 原因\n\nGitHub ActionsのCI環境でPuppeteer（Chromium）が起動できなかった。\n\n```\nNo usable sandbox! Update your kernel or see ...\n```\n\n## 修正内容\n\n`pdf-configs/config.js` の `launch_options` に `--no-sandbox` と `--disable-setuid-sandbox` を追加。\n\nGitHub Actionsのランナーはサンドボックスが使えないため、このオプションが必要。

---
_Generated by [Claude Code](https://claude.ai/code/session_01A622UzCciFNRRBygRgx8YX)_