### PR TITLE
fix: Node.js 24環境でPuppeteerのChromiumが見つからない問題を修正

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -19,9 +19,15 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
+      - name: install chromium
+        run: sudo apt-get install -y chromium-browser || sudo apt-get install -y chromium
       - run: npm install
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 'true'
       - name: build pdf
         run: npm run build:pdf
+        env:
+          PUPPETEER_EXECUTABLE_PATH: /usr/bin/chromium-browser
       - name: create release and upload asset
         uses: softprops/action-gh-release@v3
         env:


### PR DESCRIPTION
## 原因

Node.js 24環境でPuppeteer@5.3.1がバンドルされたChromiumのダウンロードに失敗し、`ENOENT` エラーが発生。

## 修正

1. aptでシステムのChromiumをインストール
2. `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true` でバンドルChromiumのダウンロードをスキップ
3. `PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser` でシステムChromiumを使用

---
_Generated by [Claude Code](https://claude.ai/code/session_01A622UzCciFNRRBygRgx8YX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration to enhance stability and consistency of PDF artifact generation across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->